### PR TITLE
Fix compilation error: Auto-application to `()` is deprecated

### DIFF
--- a/src/main/scala/rest/TrendingTopics.scala
+++ b/src/main/scala/rest/TrendingTopics.scala
@@ -22,7 +22,7 @@ object TrendingTopics extends App {
   } yield printTrendingTopics(globalTrendsResult)
 
   lazy val ukTrends = for {
-    locations <- client.locationTrends.map(_.data)
+    locations <- client.locationTrends().map(_.data)
     ukWoeid = locations.find(_.name == "United Kingdom").map(_.woeid)
     if ukWoeid.isDefined
     ukTrendsResult <- client.trends(ukWoeid.get).map(_.data)


### PR DESCRIPTION
New users will experience this issue on `sbt run`

![Screen Shot 2022-05-04 at 11 54 21 PM](https://user-images.githubusercontent.com/15316444/166861549-c5a69506-cdd0-469d-838b-d1973d4008b5.png)

Tested on Windows/Mac/Linux